### PR TITLE
Fix issue where deprecation notices were thrown in php 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.2
+### Fixed
+- Issue where in PHP 8, Deprecation Notices were thrown about missing return types.
+
 ## 1.1.1
 ### Changed
 - Package is now also installable in PHP 8.

--- a/src/UnixFileMappingReader.php
+++ b/src/UnixFileMappingReader.php
@@ -84,7 +84,7 @@ class UnixFileMappingReader implements FileMappingReaderInterface
      *
      * @return void
      */
-    public function next()
+    public function next(): void
     {
         $this->getMappings()->next();
     }
@@ -114,7 +114,7 @@ class UnixFileMappingReader implements FileMappingReaderInterface
      *
      * @return void
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->getMappings()->rewind();
     }


### PR DESCRIPTION
The alternative would be to add suppress the error, as suggested, not sure how to (easily) test this against multiple PHP versions

Example error:

Deprecation Notice: Return type of Youwe\FileMapping\UnixFileMappingReader::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/rutger/.config/composer/vendor/mediact/deployer-recipe/vendor/youwe/file-mapping/src/UnixFileMappingReader.php:87
Deprecation Notice: Return type of Youwe\FileMapping\UnixFileMappingReader::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/rutger/.config/composer/vendor/mediact/deployer-recipe/vendor/youwe/file-mapping/src/UnixFileMappingReader.php:117